### PR TITLE
Support for mutlivalue add and append cmds

### DIFF
--- a/commands/add.js
+++ b/commands/add.js
@@ -3,28 +3,39 @@ const cli = require('heroku-cli-util');
 const csv = require('./heroku-csv.js');
 
 function addCommand(context, heroku) {
-  const key = context.args.config_key;
+  if(context.args.length < 2) {
+    cli.error('At least two args required!');
+    return;
+  }
+
+  const key = context.args[0];
+  const values = context.args.slice(1);
   const app = heroku.apps(context.app);
+
   return csv.getConfigArray(app, key)
     .then((originalArr) => {
-      const valueToAdd = context.args.value_to_add;
-      if (originalArr.indexOf(valueToAdd) >= 0) {
-        cli.warn(`Config variable ${cli.color.cyan(key)} already contains ${valueToAdd}`);
-      } else {
-        const newArr = originalArr.concat([valueToAdd]);
-        return csv.setConfigArray(app, key, newArr)
-          .then(function() {
-            cli.log(`Value ${valueToAdd} added to app ${cli.color.app(context.app)} under key ${cli.color.cyan(key)}`);
-          });
+      const valuesToAdd = values.filter(v => originalArr.indexOf(v) < 0);
+      if (valuesToAdd.length === 0) {
+        cli.warn(`Config variable ${cli.color.cyan(key)} already contains all given values`);
+        return;
       }
+      for (let v of values.filter(v => originalArr.indexOf(v) >= 0)) {
+        cli.warn(`Config variable ${cli.color.cyan(key)} already contains ${v}`);
+      }
+      const newArr = originalArr.concat(valuesToAdd);
+      return csv.setConfigArray(app, key, newArr)
+        .then(function() {
+          cli.log(`Values ${valuesToAdd} added to app ${cli.color.app(context.app)} under key ${cli.color.cyan(key)}`);
+        });
     });
 }
 
 module.exports = {
   topic: 'csv',
   command: 'add',
-  description: 'Adds value to CSV config variable, if its not already there',
-  args: [{name: 'config_key'}, {name: 'value_to_add'}],
+  description: 'Adds value(s) to CSV config variable, if its not already there',
+  variableArgs: true,
+  args: [{name: 'key'}, {name: 'values...'}],
   needsApp: true,
   needsAuth: true,
   run: cli.command(addCommand)

--- a/commands/append.js
+++ b/commands/append.js
@@ -3,24 +3,29 @@ const cli = require('heroku-cli-util');
 const csv = require('./heroku-csv.js');
 
 function appendCommand(context, heroku) {
-  const key = context.args.config_key;
+  if(context.args.length < 2) {
+    cli.error('At least two args required!');
+    return;
+  }
+  const key = context.args[0];
+  const values = context.args.slice(1);
   const app = heroku.apps(context.app);
-  const value = context.args.value_to_append;
   return csv.getConfigArray(app, key)
     .then(function(originalArr) {
-      var newArr = originalArr.concat([value]);
+      var newArr = originalArr.concat(values);
       return csv.setConfigArray(app, key, newArr);
     })
   .then(function() {
-    cli.log("Value \"" + value + "\" appended to app " + cli.color.app(context.app) + " under key " + cli.color.cyan(key));
+    cli.log(`Values ${values} appended to app ${cli.color.app(context.app)} under key ${cli.color.cyan(key)}`);
   });
 }
 
 module.exports = {
   topic: 'csv',
   command: 'append',
-  description: 'Appends value to the end of CSV config variable',
-  args: [{name: 'config_key'}, {name: 'value_to_append'}],
+  description: 'Appends value(s) to the end of CSV config variable',
+  variableArgs: true,
+  args: [{name: 'key'}, {name: 'values...'}],
   needsApp: true,
   needsAuth: true,
   run: cli.command(appendCommand)


### PR DESCRIPTION
This PR adds support for multivalue `add` and `append` commands, so that one could do e.g.:

```
$ heroku csv:add FOO a b c
```

The semantics of those commands is preserved, so `add` adds only new (not-yet-existing) values (as the single-value version did), wheras `append` always adds.

:heart: 
